### PR TITLE
Fix publishing and startup of the Firebase emulator with zero custom configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           tags: spine3/firebase-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Update Datastore repo description
+      - name: Update Firebase repo description
         if: github.ref == 'refs/heads/master'
         uses: peter-evans/dockerhub-description@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./cloudtasks-emulator
-          push: github.ref == 'refs/heads/master'
+          push: endsWith(github.ref, 'refs/heads/fix-publishing')
           tags: spine3/cloudtasks-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -76,7 +76,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./datastore-emulator
-          push: github.ref == 'refs/heads/master'
+          push: endsWith(github.ref, 'refs/heads/fix-publishing')
           tags: spine3/datastore-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -116,7 +116,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./firebase-emulator
-          push: github.ref == 'refs/heads/master'
+          push: endsWith(github.ref, 'refs/heads/fix-publishing')
           tags: spine3/firebase-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./cloudtasks-emulator
-          push: endsWith(github.ref, 'refs/heads/fix-publishing')
+          push: ${{ github.ref == 'refs/heads/fix-publishing' }}
           tags: spine3/cloudtasks-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -76,7 +76,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./datastore-emulator
-          push: endsWith(github.ref, 'refs/heads/fix-publishing')
+          push: ${{ github.ref == 'refs/heads/fix-publishing' }}
           tags: spine3/datastore-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -116,11 +116,11 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./firebase-emulator
-          push: endsWith(github.ref, 'refs/heads/fix-publishing')
+          push: ${{ github.ref == 'refs/heads/fix-publishing' }}
           tags: spine3/firebase-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Update Firebase repo description
+      - name: Update Datastore repo description
         if: github.ref == 'refs/heads/master'
         uses: peter-evans/dockerhub-description@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./cloudtasks-emulator
-          push: ${{ github.ref == 'refs/heads/fix-publishing' }}
+          push: ${{ github.ref == 'refs/heads/master' }}
           tags: spine3/cloudtasks-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -76,7 +76,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./datastore-emulator
-          push: ${{ github.ref == 'refs/heads/fix-publishing' }}
+          push: ${{ github.ref == 'refs/heads/master' }}
           tags: spine3/datastore-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -116,7 +116,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./firebase-emulator
-          push: ${{ github.ref == 'refs/heads/fix-publishing' }}
+          push: ${{ github.ref == 'refs/heads/master' }}
           tags: spine3/firebase-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ docker run \
   spine3/firebase-emulator
 ```
 
+By default, the container starts the whole Firebase [emulators suite][firebase-emulator] and
+the command above exposes their TCP ports.
+
 [firebase-emulator]: https://firebase.google.com/docs/emulator-suite
 
 # Docker Compose

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Or start the emulator with the following command:
 
 ```bash
 docker run \
-    --rm \
-    -p=9090:9090 \
-    --env="GCP_PROJECT=my-project" \
-    spine3/cloudtasks-emulator
+  --rm \
+  -p=9090:9090 \
+  --env="GCP_PROJECT=my-project" \
+  spine3/cloudtasks-emulator
 ```
 
 [cloud-tasks-emulator]: https://gitlab.com/potato-oss/google-cloud/gcloud-tasks-emulator

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ the [Cloud Tasks][cloud-tasks] APIs locally.
 
 See [cloudtasks-emulator](./cloudtasks-emulator) folder for additional details.
 
+Or start the emulator with the following command:
+
+```bash
+docker run \
+    --rm \
+    -p=9090:9090 \
+    --env="GCP_PROJECT=my-project" \
+    spine3/cloudtasks-emulator
+```
+
 [cloud-tasks-emulator]: https://gitlab.com/potato-oss/google-cloud/gcloud-tasks-emulator
 [cloud-tasks]: https://cloud.google.com/tasks
 
@@ -25,6 +35,16 @@ of installing and configuring it locally.
 
 See [datastore-emulator](./datastore-emulator) folder for additional details.
 
+Or start the emulator with the following command:
+
+```bash
+docker run \
+  --rm \
+  -p=8081:8081 \
+  --env "GCP_PROJECT=my-project" \
+  spine3/datastore-emulator
+```
+
 [datastore-emulator]: https://cloud.google.com/sdk/gcloud/reference/beta/emulators/datastore
 
 ## Firebase
@@ -33,6 +53,21 @@ The [Firebase emulator][firebase-emulator] image allows reducing the hustle of s
 and configuring the emulator manually.
 
 See [firebase-emulator](./firebase-emulator) folder for additional details.
+
+Or start the emulator with the following command:
+
+```bash
+docker run \
+  --rm \
+  -p=9000:9000 \
+  -p=8080:8080 \
+  -p=4000:4000 \
+  -p=9099:9099 \
+  -p=8085:8085 \
+  -p=5001:5001 \
+  --env "GCP_PROJECT=my-project" \
+  spine3/firebase-emulator
+```
 
 [firebase-emulator]: https://firebase.google.com/docs/emulator-suite
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,17 @@ See [cloudtasks-emulator](./cloudtasks-emulator) folder for additional details.
 Or start the emulator with the following command:
 
 ```bash
+cat <<EOT >> queue.yaml
+queue:
+  - name: default
+    rate: 1/s
+EOT
+
 docker run \
   --rm \
   -p=9090:9090 \
   --env="GCP_PROJECT=my-project" \
+  --volume="$PWD/queue.yaml:/configs/queue.yaml" \
   spine3/cloudtasks-emulator
 ```
 

--- a/cloudtasks-emulator/README.md
+++ b/cloudtasks-emulator/README.md
@@ -8,11 +8,11 @@ The easiest way to start the emulator is to run the following command:
 
 ```bash
 docker run \
-    --rm \
-    -p=9090:9090 \
-    --env="GCP_PROJECT=<your-gcp-project>" \
-    --volume="$PWD/appengine/configs:/configs" \
-    cloudtasks-emulator
+  --rm \
+  -p=9090:9090 \
+  --env="GCP_PROJECT=<your-gcp-project>" \
+  --volume="$PWD/appengine/configs:/configs" \
+  spine3/cloudtasks-emulator
 ```
 
 The command above starts the emulator and exposes it on the default `9090` port assuming

--- a/cloudtasks-emulator/README.md
+++ b/cloudtasks-emulator/README.md
@@ -16,8 +16,10 @@ docker run \
 ```
 
 The command above starts the emulator and exposes it on the default `9090` port assuming
-the caller application running on the `8080` port and the `queue.yaml` configuration available
-under the `$PWD/appengine/configs` folder.
+the caller application running on the `8080` port and the [`queue.yaml`][queue-yaml] configuration 
+available under the `$PWD/appengine/configs` folder.
+
+[queue-yaml]: https://cloud.google.com/appengine/docs/standard/java/config/queueref-yaml
 
 ## Configuration
 
@@ -33,7 +35,7 @@ in the example.
 
 ### Optional configs
 
-The queues location is configured by the `QUEUE_YAML_LOCATION` environment variable and defaults
+The queues' location is configured by the `QUEUE_YAML_LOCATION` environment variable and defaults
 to the `us-central1`.
 
 The `QUEUE_YAML` environment variable allows redefining the location of the `queue.yaml` file 

--- a/datastore-emulator/README.md
+++ b/datastore-emulator/README.md
@@ -7,7 +7,11 @@ to installing and configuring it locally.
 The easiest way to start the emulator is to run the following command:
 
 ```bash
-docker run --rm -p=8081:8081 --env "GCP_PROJECT=<your-gcp-project>" datastore-emulator
+docker run \
+  --rm \
+  -p=8081:8081 \
+  --env "GCP_PROJECT=<your-gcp-project>" \
+  spine3/datastore-emulator
 ```
 
 The command above starts the emulator and exposes it on the default `8081` port.

--- a/firebase-emulator/Dockerfile
+++ b/firebase-emulator/Dockerfile
@@ -30,7 +30,7 @@ LABEL "maintainer"="developers@spine.io"
 LABEL "version"="1.0.0"
 LABEL "io.spine.emulator"="Datastore"
 
-RUN apk add --no-cache python3 py3-pip openjdk11-jre && \
+RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \
     npm install -g firebase-tools && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \

--- a/firebase-emulator/README.md
+++ b/firebase-emulator/README.md
@@ -16,7 +16,7 @@ docker run \
   -p=8085:8085 \
   -p=5001:5001 \
   --env "GCP_PROJECT=<your-gcp-project>" \
-  firebase-emulator
+  spine3/firebase-emulator
 ```
 
 The command above starts the container and exposes ports of all Firebase emulators.


### PR DESCRIPTION
This PR fixes the automatic Dockerhub publishing upon merges to the `master` branch. The previous approach did not work due to the different handling of expressions within `if` and non-`if` clauses.

Also, while we were not using the Pub/Sub emulator from the Firebase emulators suite, we were missing the `bash` dependency in the emulator's container that is required to start up the emulator.

All the `docker run` commands in the root README are verified to work with no additional setup required.