### PR TITLE
Firebase-emulator documentation: fix image name in sample command

### DIFF
--- a/firebase-emulator/README.md
+++ b/firebase-emulator/README.md
@@ -84,7 +84,7 @@ docker run \
     --publish "9999:9999" \
     --volume "$PWD/firebase_configs:/firebase" \
     --rm \
-    firebase-emulator
+    spine3/firebase-emulator
 ```
 
 #### Start more emulators


### PR DESCRIPTION
Sample command for launching firebase-emulator(docker container) with custom configuration is missing Docker Hub username(```spine3```) in image name. Below I provide suggested changes:

Before:
```
docker run \
    --name "firebase-emulator" \    
    --publish "9999:9999" \
    --volume "$PWD/firebase_configs:/firebase" \
    --rm \
    firebase-emulator
```
After:
```
docker run \
    --name "firebase-emulator" \    
    --publish "9999:9999" \
    --volume "$PWD/firebase_configs:/firebase" \
    --rm \
    spine3/firebase-emulator
````