### PR TITLE
Improve CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ '*', '!master' ]
   workflow_dispatch:
 
 defaults:
@@ -27,27 +27,13 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and Push CloudTasks emulator
+      - name: Build CloudTasks emulator
         uses: docker/build-push-action@v2
         with:
           context: ./cloudtasks-emulator
-          push: ${{ github.ref == 'refs/heads/master' }}
-          tags: spine3/cloudtasks-emulator:latest
+          push: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Update CloudTasks repo description
-        if: github.ref == 'refs/heads/master'
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: spine3/cloudtasks-emulator
-          readme-filepath: ./cloudtasks-emulator/README.md
 
   datastore:
     name: Build Datastore Emulator
@@ -67,27 +53,13 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and Push Datastore emulator
+      - name: Build Datastore emulator
         uses: docker/build-push-action@v2
         with:
           context: ./datastore-emulator
-          push: ${{ github.ref == 'refs/heads/master' }}
-          tags: spine3/datastore-emulator:latest
+          push: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Update Datastore repo description
-        if: github.ref == 'refs/heads/master'
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: spine3/datastore-emulator
-          readme-filepath: ./datastore-emulator/README.md
 
   firebase:
     name: Build Firebase Emulator
@@ -107,24 +79,10 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push Firebase emulator
         uses: docker/build-push-action@v2
         with:
           context: ./firebase-emulator
-          push: ${{ github.ref == 'refs/heads/master' }}
-          tags: spine3/firebase-emulator:latest
+          push: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Update Datastore repo description
-        if: github.ref == 'refs/heads/master'
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: spine3/firebase-emulator
-          readme-filepath: ./firebase-emulator/README.md

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,127 @@
+name: Build and Publish
+
+on:
+  push:
+    branches: [ 'master' ]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+jobs:
+  cloudtasks:
+    name: Build CloudTasks Emulator
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup BuildX
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push CloudTasks emulator
+        uses: docker/build-push-action@v2
+        with:
+          context: ./cloudtasks-emulator
+          push: true
+          tags: spine3/cloudtasks-emulator:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Update CloudTasks repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: spine3/cloudtasks-emulator
+          readme-filepath: ./cloudtasks-emulator/README.md
+
+  datastore:
+    name: Build Datastore Emulator
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup BuildX
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push Datastore emulator
+        uses: docker/build-push-action@v2
+        with:
+          context: ./datastore-emulator
+          push: true
+          tags: spine3/datastore-emulator:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Update Datastore repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: spine3/datastore-emulator
+          readme-filepath: ./datastore-emulator/README.md
+
+  firebase:
+    name: Build Firebase Emulator
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup BuildX
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push Firebase emulator
+        uses: docker/build-push-action@v2
+        with:
+          context: ./firebase-emulator
+          push: true
+          tags: spine3/firebase-emulator:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Update Datastore repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: spine3/firebase-emulator
+          readme-filepath: ./firebase-emulator/README.md

--- a/cloudtasks-emulator/Dockerfile
+++ b/cloudtasks-emulator/Dockerfile
@@ -35,7 +35,7 @@ RUN pip install --requirement /requirements.txt --no-warn-script-location --no-c
 
 FROM python:3.7-slim AS app-env
 LABEL "maintainer"="developers@spine.io"
-LABEL "version"="1.0.0"
+LABEL "version"="1.0.1"
 LABEL "io.spine.emulator"="CloudTasks"
 
 ENV GCP_PROJECT="change-me"

--- a/datastore-emulator/Dockerfile
+++ b/datastore-emulator/Dockerfile
@@ -27,7 +27,7 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine AS app-env
 
 LABEL "maintainer"="developers@spine.io"
-LABEL "version"="1.0.0"
+LABEL "version"="1.0.1"
 LABEL "io.spine.emulator"="Datastore"
 
 RUN apk add openjdk11-jre && \

--- a/firebase-emulator/Dockerfile
+++ b/firebase-emulator/Dockerfile
@@ -27,7 +27,7 @@
 FROM node:lts-alpine3.13 AS app-env
 
 LABEL "maintainer"="developers@spine.io"
-LABEL "version"="1.1.0"
+LABEL "version"="1.1.1"
 LABEL "io.spine.emulator"="Firebase"
 
 RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \


### PR DESCRIPTION
This PR addresses the issue with the usage of the repository secrets in PRs of outside collaborators.

Consider PR #3 as an example. In the PR GH actions were never started while we're dealing with a source code branch from a fork that is not considered "secure", thus secrets are not revealed.

With the changes introduced in this PR, we'll not use our secrets for non-master branches. This allows overcoming the security restriction by letting GH Actions build containers, but not publish or update the Docker registry from within PRs.