### PR TITLE
Cloud Storage emulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           path: /tmp/.buildx-cache-cloudtasks
           key: ${{ runner.os }}-buildx-cloudtasks-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-cloudtasks
+            ${{ runner.os }}-buildx-cloudtasks-
       - name: Build CloudTasks emulator
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,17 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          path: /tmp/.buildx-cache-cloudtasks
+          key: ${{ runner.os }}-buildx-cloudtasks-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-cloudtasks
       - name: Build CloudTasks emulator
         uses: docker/build-push-action@v2
         with:
           context: ./cloudtasks-emulator
           push: false
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-cloudtasks
+          cache-to: type=local,dest=/tmp/.buildx-cache-cloudtasks
 
   cloud-storage:
     name: Build Cloud Storage Emulator
@@ -49,17 +49,17 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          path: /tmp/.buildx-cache-cloudstorage
+          key: ${{ runner.os }}-buildx-cloudstorage-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-cloudstorage-
       - name: Build Cloud Storage emulator
         uses: docker/build-push-action@v2
         with:
           context: ./cloudstorage-emulator
           push: false
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-cloudstorage
+          cache-to: type=local,dest=/tmp/.buildx-cache-cloudstorage
 
   datastore:
     name: Build Datastore Emulator
@@ -75,17 +75,17 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          path: /tmp/.buildx-cache-datastore
+          key: ${{ runner.os }}-buildx-datastore-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-datastore-
       - name: Build Datastore emulator
         uses: docker/build-push-action@v2
         with:
           context: ./datastore-emulator
           push: false
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-datastore
+          cache-to: type=local,dest=/tmp/.buildx-cache-datastore
 
   firebase:
     name: Build Firebase Emulator
@@ -101,14 +101,14 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          path: /tmp/.buildx-cache-firebase
+          key: ${{ runner.os }}-buildx-firebase-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-firebase-
       - name: Build and Push Firebase emulator
         uses: docker/build-push-action@v2
         with:
           context: ./firebase-emulator
           push: false
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-firebase
+          cache-to: type=local,dest=/tmp/.buildx-cache-firebase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,32 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
+  cloud-storage:
+    name: Build Cloud Storage Emulator
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup BuildX
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build Cloud Storage emulator
+        uses: docker/build-push-action@v2
+        with:
+          context: ./cloudstorage-emulator
+          push: false
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
   datastore:
     name: Build Datastore Emulator
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache-cloudtasks
           cache-to: type=local,dest=/tmp/.buildx-cache-cloudtasks
 
-  cloud-storage:
+  cloudstorage:
     name: Build Cloud Storage Emulator
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -48,6 +48,44 @@ jobs:
           repository: spine3/cloudtasks-emulator
           readme-filepath: ./cloudtasks-emulator/README.md
 
+  cloud-storage:
+    name: Build Cloud Storage Emulator
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup BuildX
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-cloudstorage
+          key: ${{ runner.os }}-buildx-cloudstorage-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-cloudstorage-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build Cloud Storage emulator
+        uses: docker/build-push-action@v2
+        with:
+          context: ./cloudstorage-emulator
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache-cloudstorage
+          cache-to: type=local,dest=/tmp/.buildx-cache-cloudstorage
+      - name: Update Cloud Storage repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: spine3/cloudstorage-emulator
+          readme-filepath: ./cloudstorage-emulator/README.md
+
   datastore:
     name: Build Datastore Emulator
     runs-on: ubuntu-20.04

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,9 +9,34 @@ defaults:
   run:
     shell: bash
 jobs:
-  cloudtasks:
-    name: Build CloudTasks Emulator
+  # Detects per-folder changes inside the repository
+  changes:
     runs-on: ubuntu-20.04
+    outputs:
+      cloudtasks: ${{ steps.filter.outputs.cloudtasks }}
+      cloudstorage: ${{ steps.filter.outputs.cloudstorage }}
+      datastore: ${{ steps.filter.outputs.datastore }}
+      firebase: ${{ steps.filter.outputs.firebase }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          token: ${{ github.token }}
+          filters: |
+            cloudtasks:
+              - 'cloudtasks-emulator/**'
+            cloudstorage:
+              - 'cloudstorage-emulator/**'
+            datastore:
+              - 'datastore-emulator/**'
+            firebase:
+              - 'firebase-emulator/**'
+  cloudtasks:
+    name: Build and Publish CloudTasks Emulator
+    runs-on: ubuntu-20.04
+    needs: [ 'changes' ]
+    if: ${{ needs.changes.outputs.cloudtasks == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -48,9 +73,11 @@ jobs:
           repository: spine3/cloudtasks-emulator
           readme-filepath: ./cloudtasks-emulator/README.md
 
-  cloud-storage:
-    name: Build Cloud Storage Emulator
+  cloudstorage:
+    name: Build and Publish Cloud Storage Emulator
     runs-on: ubuntu-20.04
+    needs: [ 'changes' ]
+    if: ${{ needs.changes.outputs.cloudstorage == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -87,8 +114,10 @@ jobs:
           readme-filepath: ./cloudstorage-emulator/README.md
 
   datastore:
-    name: Build Datastore Emulator
+    name: Build and Publish Datastore Emulator
     runs-on: ubuntu-20.04
+    needs: [ 'changes' ]
+    if: ${{ needs.changes.outputs.datastore == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -126,8 +155,10 @@ jobs:
           readme-filepath: ./datastore-emulator/README.md
 
   firebase:
-    name: Build Firebase Emulator
+    name: Build and Publish Firebase Emulator
     runs-on: ubuntu-20.04
+    needs: [ 'changes' ]
+    if: ${{ needs.changes.outputs.firebase == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          path: /tmp/.buildx-cache-cloudtasks
+          key: ${{ runner.os }}-buildx-cloudtasks-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-cloudtasks-
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -38,8 +38,8 @@ jobs:
           context: ./cloudtasks-emulator
           push: true
           tags: spine3/cloudtasks-emulator:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-cloudtasks
+          cache-to: type=local,dest=/tmp/.buildx-cache-cloudtasks
       - name: Update CloudTasks repo description
         uses: peter-evans/dockerhub-description@v2
         with:
@@ -62,10 +62,10 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          path: /tmp/.buildx-cache-datastore
+          key: ${{ runner.os }}-buildx-datastore-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-datastore-
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -77,8 +77,8 @@ jobs:
           context: ./datastore-emulator
           push: true
           tags: spine3/datastore-emulator:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-datastore
+          cache-to: type=local,dest=/tmp/.buildx-cache-datastore
       - name: Update Datastore repo description
         uses: peter-evans/dockerhub-description@v2
         with:
@@ -101,10 +101,10 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          path: /tmp/.buildx-cache-firebase
+          key: ${{ runner.os }}-buildx-firebase-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-firebase-
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -116,8 +116,8 @@ jobs:
           context: ./firebase-emulator
           push: true
           tags: spine3/firebase-emulator:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-firebase
+          cache-to: type=local,dest=/tmp/.buildx-cache-firebase
       - name: Update Datastore repo description
         uses: peter-evans/dockerhub-description@v2
         with:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ docker run \
 [cloud-tasks-emulator]: https://gitlab.com/potato-oss/google-cloud/gcloud-tasks-emulator
 [cloud-tasks]: https://cloud.google.com/tasks
 
+## Cloud Storage
+
+The [Cloud Storage emulator][cloud-storage-emulator] provides a way to work with
+the [Cloud Storage][cloud-storage] APIs locally.
+
+See [cloudstorage-emulator](./cloudstorage-emulator) folder for additional details.
+
+Or start the emulator with the following command:
+
+```bash
+docker run \
+  --rm \
+  -p=9199:9199 \
+  spine3/cloudstorage-emulator
+```
+
+[cloud-storage-emulator]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage/emulator
+[cloud-storage]: https://cloud.google.com/storage
+
 ## Datastore
 
 The [Datastore emulator][datastore-emulator] image allows starting the emulator without the need

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,6 +39,15 @@ steps:
     waitFor: [ "-" ]
 
   - name: "gcr.io/cloud-builders/docker"
+    id: "cloudstorage-emulator"
+    args: [
+        "build",
+        "-t", "gcr.io/${PROJECT_ID}/cloudstorage-emulator",
+        "./cloudstorage-emulator"
+    ]
+    waitFor: [ "-" ]
+
+  - name: "gcr.io/cloud-builders/docker"
     id: "datastore-emulator"
     args: [
         "build",
@@ -58,6 +67,7 @@ steps:
 
 images: [
     "gcr.io/${PROJECT_ID}/cloudtasks-emulator",
+    "gcr.io/${PROJECT_ID}/cloudstorage-emulator",
     "gcr.io/${PROJECT_ID}/datastore-emulator",
     "gcr.io/${PROJECT_ID}/firebase-emulator"
 ]

--- a/cloudstorage-emulator/Dockerfile
+++ b/cloudstorage-emulator/Dockerfile
@@ -1,0 +1,61 @@
+#
+# Copyright 2021, TeamDev. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+FROM python:3.7-stretch AS build-env
+
+RUN python3 -m pip install --upgrade pip wheel setuptools
+
+# Clone `google-cloud-cpp` repo in order to install the GCS emulator locally. Then go into the
+# emulator folder and install required dependencies.
+RUN git clone https://github.com/googleapis/google-cloud-cpp.git \
+  --branch main \
+  --single-branch \
+  --depth 1 \
+  /cloud-cpp \
+  && cd "cloud-cpp/google/cloud/storage/emulator" \
+  && rm -rf "tests" \
+  && python3 -m pip install -r requirements.txt --no-warn-script-location --no-cache-dir
+
+FROM python:3.7-slim AS app-env
+LABEL "maintainer"="developers@spine.io"
+LABEL "version"="1.0.0"
+LABEL "io.spine.emulator"="CloudStorage"
+
+RUN mkdir /configs
+VOLUME /configs
+
+# Copy installed Python packages from the build environment.
+COPY --from=build-env /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+# Copy the emulator intself from the build environment.
+COPY --from=build-env /cloud-cpp/google/cloud/storage/emulator /app
+WORKDIR /app
+COPY runner.sh .
+RUN chmod +x runner.sh
+
+ENV EMULATOR_PORT="9199"
+ENV EMULATOR_HOST="0.0.0.0"
+
+ENTRYPOINT [ "./runner.sh" ]

--- a/cloudstorage-emulator/LICENSE
+++ b/cloudstorage-emulator/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cloudstorage-emulator/README.md
+++ b/cloudstorage-emulator/README.md
@@ -1,0 +1,29 @@
+Cloud Storage emulator
+---------
+
+The [Cloud Storage emulator][emulator] provides a way to work with the [Cloud Storage][cloud-storage] 
+APIs locally.
+
+The easiest way to start the emulator is to run the following command:
+
+```bash
+docker run \
+  --rm \
+  -p=9199:9199 \
+  spine3/cloudstorage-emulator
+```
+
+The command above starts the emulator and exposes it on the default `9199` port.
+
+## Configuration
+
+The image is configured using a set of environment variables, and a shared volume with 
+the configuration files.
+
+The `EMULATOR_PORT` allows configuring the port on which the emulator is started
+within the container.
+
+The `EMULATORS_HOST` variable configures the host used by the emulator and defaults to `0.0.0.0`.
+
+[emulator]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage/emulator
+[cloud-storage]: https://cloud.google.com/storage

--- a/cloudstorage-emulator/README.md
+++ b/cloudstorage-emulator/README.md
@@ -1,7 +1,7 @@
-Cloud Storage emulator
+Cloud Storage Emulator
 ---------
 
-The [Cloud Storage emulator][emulator] provides a way to work with the [Cloud Storage][cloud-storage] 
+The [Cloud Storage Emulator][emulator] provides a way to work with the [Cloud Storage][cloud-storage] 
 APIs locally.
 
 The easiest way to start the emulator is to run the following command:

--- a/cloudstorage-emulator/cloudbuild.yaml
+++ b/cloudstorage-emulator/cloudbuild.yaml
@@ -1,0 +1,42 @@
+#
+# Copyright 2021, TeamDev. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# This Cloud Build configuration builds Cloud Storage emulator Docker image and stores it
+# in the GCP project of choice.
+#
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    id: "cloudstorage-emulator"
+    args: [
+        "build",
+        "-t", "gcr.io/${PROJECT_ID}/cloudstorage-emulator",
+        "."
+    ]
+
+images: [
+    "gcr.io/${PROJECT_ID}/cloudstorage-emulator"
+]

--- a/cloudstorage-emulator/runner.sh
+++ b/cloudstorage-emulator/runner.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+#
+# Copyright 2021, TeamDev. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# This script starts the local Cloud Storage emulator at the port denoted by the `EMULATOR_PORT`
+# env variable or `9199` by default.
+#
+# One may additionally configure the `EMULATORS_HOST` env variable to prevent running
+# the emulator in the broadcast `0.0.0.0` mode.
+
+export EMULATOR_PORT="${EMULATOR_PORT:-9199}"
+export EMULATOR_HOST="${EMULATOR_HOST:-0.0.0.0}"
+
+EMULATOR_ADDRESS="${EMULATOR_HOST}:${EMULATOR_PORT}"
+
+python3 -m gunicorn --bind "${EMULATOR_ADDRESS}" --worker-class sync --threads 10 "emulator:run()"

--- a/cloudtasks-emulator/README.md
+++ b/cloudtasks-emulator/README.md
@@ -1,7 +1,7 @@
-Cloud Tasks emulator
+Cloud Tasks Emulator
 ---------
 
-The [Cloud Tasks emulator][emulator] provides a way to work with the [Cloud Tasks][cloud-tasks] 
+The [Cloud Tasks Emulator][emulator] provides a way to work with the [Cloud Tasks][cloud-tasks] 
 APIs locally.
 
 The easiest way to start the emulator is to run the following command:

--- a/datastore-emulator/README.md
+++ b/datastore-emulator/README.md
@@ -1,7 +1,7 @@
-Datastore emulator
+Datastore Emulator
 ---------
 
-The [Datastore emulator][emulator] image allows starting the emulator without the need
+The [Datastore Emulator][emulator] image allows starting the emulator without the need
 to installing and configuring it locally.
 
 The easiest way to start the emulator is to run the following command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,14 @@ services:
     environment:
       GCP_PROJECT: "<GCP_PROJECT>"
       EMULATOR_PORT: "9999"
+  cloudstorage-emulator:
+    image: cloudstorage-emulator
+    ports:
+      - target: 9999
+        published: 9199
+        protocol: tcp
+    environment:
+      EMULATOR_PORT: "9999"
   firebase-emulator:
     image: firebase-emulator
     ports:

--- a/firebase-emulator/README.md
+++ b/firebase-emulator/README.md
@@ -1,4 +1,4 @@
-Firebase Emulator Suite container
+Firebase Emulator Suite
 ---------
 
 The [Firebase Emulator Suite][emulator] image allows reducing the hustle of setting up and


### PR DESCRIPTION
In this PR I have introduced a setup for a reusable Cloud Storage [emulator](https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/storage/emulator).

The emulator may be started using the following command:

```
docker run \
  --rm \
  -p=9199:9199 \
  spine3/cloudstorage-emulator
```

As part of the PR, I have also introduced a change to the CI/CD config which allows building and publishing emulator containers only when smth has actually changed for a particular container. Such an approach allows to improve the build speed, reduces the environmental impact as well as allows to skip bumping up versions for emulators which were not changed.
I have also improved the caching setup in order to ensure that we're not overriding the `buildx` cache from different jobs.