### PR TITLE
Fix Cloud Storage Emulator publishing

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -62,7 +62,10 @@ jobs:
         with:
           context: ./cloudtasks-emulator
           push: true
-          tags: spine3/cloudtasks-emulator:latest
+          tags: |
+            spine3/cloudtasks-emulator:latest
+            spine3/cloudtasks-emulator:${GITHUB_SHA}
+            spine3/cloudtasks-emulator:${GITHUB_SHA:0:7}
           cache-from: type=local,src=/tmp/.buildx-cache-cloudtasks
           cache-to: type=local,dest=/tmp/.buildx-cache-cloudtasks
       - name: Update CloudTasks repo description
@@ -103,7 +106,10 @@ jobs:
         with:
           context: ./cloudstorage-emulator
           push: true
-          tags: spine3/cloudstorage-emulator:latest
+          tags: |
+            spine3/cloudstorage-emulator:latest
+            spine3/cloudstorage-emulator:${GITHUB_SHA}
+            spine3/cloudstorage-emulator:${GITHUB_SHA:0:7}
           cache-from: type=local,src=/tmp/.buildx-cache-cloudstorage
           cache-to: type=local,dest=/tmp/.buildx-cache-cloudstorage
       - name: Update Cloud Storage repo description
@@ -144,7 +150,10 @@ jobs:
         with:
           context: ./datastore-emulator
           push: true
-          tags: spine3/datastore-emulator:latest
+          tags: |
+            spine3/datastore-emulator:latest
+            spine3/datastore-emulator:${GITHUB_SHA}
+            spine3/datastore-emulator:${GITHUB_SHA:0:7}
           cache-from: type=local,src=/tmp/.buildx-cache-datastore
           cache-to: type=local,dest=/tmp/.buildx-cache-datastore
       - name: Update Datastore repo description
@@ -185,7 +194,10 @@ jobs:
         with:
           context: ./firebase-emulator
           push: true
-          tags: spine3/firebase-emulator:latest
+          tags: |
+            spine3/firebase-emulator:latest
+            spine3/firebase-emulator:${GITHUB_SHA}
+            spine3/firebase-emulator:${GITHUB_SHA:0:7}
           cache-from: type=local,src=/tmp/.buildx-cache-firebase
           cache-to: type=local,dest=/tmp/.buildx-cache-firebase
       - name: Update Datastore repo description

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           context: ./cloudstorage-emulator
           push: true
+          tags: spine3/cloudstorage-emulator:latest
           cache-from: type=local,src=/tmp/.buildx-cache-cloudstorage
           cache-to: type=local,dest=/tmp/.buildx-cache-cloudstorage
       - name: Update Cloud Storage repo description


### PR DESCRIPTION
In this PR I have added the missing `tags` config parameter for the Cloud Storage Emulator container.

As part of the PR I have also exposed git SHA as container tags which is a common practice in the industry that allows preventing using "latest" image always as "latest" may have incompatibilities.
