### PR TITLE
Bump versions.

### DIFF
--- a/cloudstorage-emulator/Dockerfile
+++ b/cloudstorage-emulator/Dockerfile
@@ -41,7 +41,7 @@ RUN git clone https://github.com/googleapis/google-cloud-cpp.git \
 
 FROM python:3.7-slim AS app-env
 LABEL "maintainer"="developers@spine.io"
-LABEL "version"="1.0.0"
+LABEL "version"="1.0.1"
 LABEL "io.spine.emulator"="CloudStorage"
 
 RUN mkdir /configs

--- a/cloudtasks-emulator/Dockerfile
+++ b/cloudtasks-emulator/Dockerfile
@@ -35,7 +35,7 @@ RUN pip install --requirement /requirements.txt --no-warn-script-location --no-c
 
 FROM python:3.7-slim AS app-env
 LABEL "maintainer"="developers@spine.io"
-LABEL "version"="1.0.1"
+LABEL "version"="1.0.2"
 LABEL "io.spine.emulator"="CloudTasks"
 
 ENV GCP_PROJECT="change-me"

--- a/datastore-emulator/Dockerfile
+++ b/datastore-emulator/Dockerfile
@@ -27,7 +27,7 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine AS app-env
 
 LABEL "maintainer"="developers@spine.io"
-LABEL "version"="1.0.1"
+LABEL "version"="1.0.2"
 LABEL "io.spine.emulator"="Datastore"
 
 RUN apk add openjdk11-jre && \

--- a/firebase-emulator/Dockerfile
+++ b/firebase-emulator/Dockerfile
@@ -27,7 +27,7 @@
 FROM node:lts-alpine3.13 AS app-env
 
 LABEL "maintainer"="developers@spine.io"
-LABEL "version"="1.1.1"
+LABEL "version"="1.1.2"
 LABEL "io.spine.emulator"="Firebase"
 
 RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \


### PR DESCRIPTION
Another attempt to publish containers.

The previous run was skipped due to the new "smart" path filters.